### PR TITLE
fix: support all angular 14 versions

### DIFF
--- a/projects/ngx-pinch-zoom/package.json
+++ b/projects/ngx-pinch-zoom/package.json
@@ -36,8 +36,8 @@
     "url": "https://github.com/konstantinschuette/ngx-pinch-zoom/issues"
   },
   "peerDependencies": {
-      "@angular/common": "^14.2.0",
-      "@angular/core": "^14.2.0"
+      "@angular/common": "^14.0.0",
+      "@angular/core": "^14.0.0"
   },
   "dependencies": {
     "tslib": "^2.0.0"


### PR DESCRIPTION
currently peer dependency is set to `^14.2.0`, which will cause "could not resolve dependency" error with older angular 14 versions using `npm i @meddv/ngx-pinch-zoom` although these are compatible with each other