### PR TITLE
Connect limitZoom with maxScale between PinchZoomComponent and IvyPinch.

### DIFF
--- a/projects/ngx-pinch-zoom/src/lib/ivypinch.ts
+++ b/projects/ngx-pinch-zoom/src/lib/ivypinch.ts
@@ -48,6 +48,8 @@ export class IvyPinch {
             return;
         }
 
+        if(typeof properties.limitZoom === 'number')
+            this.maxScale = properties.limitZoom;
         this.elementTarget = this.element.querySelector('*').tagName;
         this.parentElement = this.element.parentElement;
         this.properties = Object.assign({}, defaultProperties, properties);
@@ -541,7 +543,9 @@ export class IvyPinch {
     }
 
     detectLimitZoom() {
-        this.maxScale = this.defaultMaxScale;
+        // Assign to default only if it is not passed through constructor
+        if(!this.maxScale)
+            this.maxScale = this.defaultMaxScale;
 
         if (this.properties.limitZoom === 'original image size' && this.elementTarget === 'IMG') {
             // We are waiting for the element with the image to be available

--- a/projects/ngx-pinch-zoom/src/lib/ivypinch.ts
+++ b/projects/ngx-pinch-zoom/src/lib/ivypinch.ts
@@ -544,8 +544,7 @@ export class IvyPinch {
 
     detectLimitZoom() {
         // Assign to default only if it is not passed through constructor
-        if(!this.maxScale)
-            this.maxScale = this.defaultMaxScale;
+        this.maxScale ??= this.defaultMaxScale;
 
         if (this.properties.limitZoom === 'original image size' && this.elementTarget === 'IMG') {
             // We are waiting for the element with the image to be available

--- a/projects/ngx-pinch-zoom/src/lib/pinch-zoom.component.ts
+++ b/projects/ngx-pinch-zoom/src/lib/pinch-zoom.component.ts
@@ -232,6 +232,7 @@ export class PinchZoomComponent implements OnDestroy {
             return;
         }
 
+        this.properties.limitZoom = this.limitZoom;
         this.properties['element'] = this.elementRef.nativeElement.querySelector('.pinch-zoom-content');
         this.pinchZoom = new IvyPinch(this.properties);
     }


### PR DESCRIPTION
When setting `limit-zoom` through html it had no effect as the maximum scale was always 3 by default. I added the logic that passes the limitZoom property to IvyPinch and that sets maxScale in IvyPinch to the previously passed limitZoom. In the `detectLimitZoom()` function the maxScale goes to default only if no limitZoom was passed from the component.