### PR TITLE
Implement zoom in and out methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,12 @@ For use, put your image inside the &lt;pinch-zoom&gt; container. Please, pay att
 
 ## Methods
 
-| name         | description                                                                                  |
-| ------------ | -------------------------------------------------------------------------------------------- |
-| toggleZoom() | Image zooming in and out, depending on its current state.                                    |
-| destroy()    | Unsubscribe from mouse events and touches, as well as remove added styles from the DOM tree. |
+| name                   | description                                                                                  |
+| ---------------------- | -------------------------------------------------------------------------------------------- |
+| toggleZoom()           | Image zooming in and out, depending on its current state.                                    |
+| zoomIn(value: number)  | Zoom in by `value`, respects `limit-zoom` option. Returns `scale: number`.                   |
+| zoomOut(value: number) | Zoom out by `value`, respects `minScale` option. Returns `scale: number`.                    |
+| destroy()              | Unsubscribe from mouse events and touches, as well as remove added styles from the DOM tree. |
 
 See the full documentation and examples on the [home page](http://ivylab.space/pinch-zoom).
 

--- a/projects/ngx-pinch-zoom/src/lib/ivypinch.ts
+++ b/projects/ngx-pinch-zoom/src/lib/ivypinch.ts
@@ -619,6 +619,34 @@ export class IvyPinch {
         }
     }
 
+    public zoomIn(value: number): number {
+        const scale = this.scale + value;
+
+        if (scale >= this.maxScale) {
+            this.scale = this.maxScale;
+
+            return this.scale;
+        }
+
+        this.setZoom({ scale });
+
+        return this.scale;
+    }
+
+    public zoomOut(value: number): number {
+        const scale = this.scale - value;
+
+        if (scale <= this.properties.minScale) {
+            this.scale = this.properties.minScale;
+
+            return this.scale;
+        }
+
+        this.setZoom({ scale });
+
+        return this.scale;
+    }
+
     private setZoom(properties: { scale: number; center?: number[] }): void {
         this.scale = properties.scale;
 

--- a/projects/ngx-pinch-zoom/src/lib/pinch-zoom.component.ts
+++ b/projects/ngx-pinch-zoom/src/lib/pinch-zoom.component.ts
@@ -274,6 +274,14 @@ export class PinchZoomComponent implements OnInit, OnDestroy, OnChanges {
         this.pinchZoom?.toggleZoom();
     }
 
+    zoomIn(value: number): number {
+        return this.pinchZoom?.zoomIn(value);
+    }
+
+    zoomOut(value: number): number {
+        return this.pinchZoom?.zoomOut(value);
+    }
+
     isControl(): boolean {
         if (this.isDisabled) {
             return false;


### PR DESCRIPTION
Adds methods to zoom in and out by `value`, returns the new scale. Keeps current viewport center.